### PR TITLE
feat/populate-codices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .DS_Store
 node_modules/
+*fixedpdfconversion.json
 *rawpdfconversion.json
 *easyarray.json
 *easycodices.json
 *populatedcodices.json
+*cleanedcodices.json
 *.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules/
+*rawpdfconversion.json
 *easyarray.json
 *easycodices.json
-*rawpdfconversion.json
+*populatedcodices.json
 *.pdf

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "node src/test.js",
     "convertpdf": "node src/parse-pdf.js creature-codex-5e.pdf",
     "parsecodices": "node src/parse-codices.js",
-    "populatecodices": "node src/populate-codices.js"
+    "populatecodices": "node src/populate-codices.js",
+    "cleancodices": "node src/clean-codices.js"
   },
   "dependencies": {
     "pdf2json": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "node src/test.js",
     "convertpdf": "node src/parse-pdf.js creature-codex-5e.pdf",
-    "parsecodices": "node src/parse-codices.js"
+    "parsecodices": "node src/parse-codices.js",
+    "populatecodices": "node src/populate-codices.js"
   },
   "dependencies": {
     "pdf2json": "^1.2.0"

--- a/src/clean-codices.js
+++ b/src/clean-codices.js
@@ -1,0 +1,69 @@
+const fs = require('fs')
+const path = require('path')
+const inquirer = require('inquirer')
+// const chalk = require('chalk');
+const consts = require('./common/consts')
+
+const date = new Date().toLocaleString('en-AU')
+const isoDate = new Date(date).toISOString()
+
+const files = fs.readdirSync(path.join(__dirname, '..', 'resources/json'))
+
+const questions = [
+    {
+        type: 'list',
+        name: 'FILELOCATION',
+        message: 'Which Populated Codices file should be loaded?',
+        choices: files
+    }
+]
+
+const loadFile = (fileName) => {
+    let strFormatted = ''
+    const fileContent = fs.readFileSync(fileName)
+    const codices2DArray = JSON.parse(fileContent)
+
+    codices2DArray.forEach((codexStringArray) => {
+        codexStringArray.forEach((string, index) => {
+            strFormatted = string.toString()
+            if (
+                strFormatted.charAt(0) === '.' &&
+                strFormatted.charAt(1) === ' '
+            ) {
+                const temp = strFormatted.charAt(2).toUpperCase()
+                codexStringArray[index] = temp.concat(strFormatted.substring(3))
+            }
+        })
+    })
+    console.log(`Successfully finished cleaning Creature Codices`)
+
+    fs.writeFile(
+        path.join(
+            __dirname,
+            '..',
+            `/resources/json/${isoDate}-cleanedcodices.json`
+        ),
+        JSON.stringify(codices2DArray),
+        () => {
+            console.dir(codices2DArray, { maxArrayLength: 4 })
+        }
+    )
+}
+
+inquirer
+    .prompt(questions)
+    .then((answers) => {
+        const { FILELOCATION } = answers
+        loadFile(
+            path.join(__dirname + '/..' + '/resources/json/' + FILELOCATION)
+        )
+    })
+    .catch((error) => {
+        if (error.isTtyError) {
+            console.log(
+                "Prompt couldn't be rendered in the current environment"
+            )
+        } else {
+            console.log('Error performing Inquirer:', error)
+        }
+    })

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -25,6 +25,43 @@ const codices = [
     'CODEX X',
     'CODEX Y',
     'CODEX Z',
-    'Appendix A: NPC Codex'
+    'Appendix A: NPC Codex',
 ]
-module.exports.codices = codices;
+
+const brokenDecodedTextList = [
+    {
+        brokenEncoding: '%26',
+        fixedEncoding: 'ft',
+        flagElements: 1,
+    },
+    {
+        brokenEncoding: '%23',
+        fixedEncoding: 'th',
+        flagElements: 1,
+    },
+    {
+        brokenEncoding: '%22',
+        fixedEncoding: 'wh',
+        flagElements: 1,
+    },
+    {
+        brokenEncoding: ')',
+        fixedEncoding: 'fl',
+        flagElements: 1,
+    },
+    {
+        brokenEncoding: '!',
+        fixedEncoding: 'fi',
+        flagElements: 1,
+    },
+]
+
+const emailMeta = 'Sean Carmichael - sean.carimchael2@gmail.com - 267728'
+const codicesBreakPoint = 'Zoog'
+const finalCodicesPage = '397'
+
+module.exports.finalCodicesPage = finalCodicesPage
+module.exports.brokenDecodedTextList = brokenDecodedTextList
+module.exports.emailMeta = emailMeta
+module.exports.codicesBreakPoint = codicesBreakPoint
+module.exports.codices = codices

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -25,35 +25,46 @@ const codices = [
     'CODEX X',
     'CODEX Y',
     'CODEX Z',
-    'Appendix A: NPC Codex',
+    'Appendix A: NPC Codex'
 ]
 
 const brokenDecodedTextList = [
     {
         brokenEncoding: '%26',
         fixedEncoding: 'ft',
-        flagElements: 1,
+        flagElements: 1
     },
     {
         brokenEncoding: '%23',
         fixedEncoding: 'th',
-        flagElements: 1,
+        flagElements: 1
     },
     {
         brokenEncoding: '%22',
         fixedEncoding: 'wh',
-        flagElements: 1,
+        flagElements: 1
     },
     {
         brokenEncoding: ')',
         fixedEncoding: 'fl',
-        flagElements: 1,
+        flagElements: 1
     },
     {
         brokenEncoding: '!',
         fixedEncoding: 'fi',
-        flagElements: 1,
+        flagElements: 1
     },
+    {
+        brokenEncoding: "'",
+        fixedEncoding: 'fi',
+        flagElements: 1
+    },
+    {
+        brokenEncoding: '$',
+        fixedEncoding: 'ff',
+        alternateFixedEncoding: 'Th',
+        flagElements: 1
+    }
 ]
 
 const emailMeta = 'Sean Carmichael - sean.carimchael2@gmail.com - 267728'

--- a/src/common/handle-broken-encoding.js
+++ b/src/common/handle-broken-encoding.js
@@ -1,0 +1,5 @@
+const handleBrokenEncoding = (newText) => {
+    return ''
+}
+
+module.exports.handleBrokenEncoding = handleBrokenEncoding

--- a/src/parse-codices.js
+++ b/src/parse-codices.js
@@ -39,9 +39,7 @@ const loadFile = (fileName) => {
                     let i = textsIndex + 1
                     // console.log('i =', i)
                     // console.log(`easyArray[${i}] = ${easyArray[i]}`)
-                    while (
-                        easyArray[i] !== consts.codices[codicesIndex + 1]
-                    ) {
+                    while (easyArray[i] !== consts.codices[codicesIndex + 1]) {
                         if (finishCodices) {
                             throw BreakException
                         }
@@ -65,10 +63,6 @@ const loadFile = (fileName) => {
                                 j = easyArray[i + 3].toString()
                                 i += 1
                             }
-                            console.log('page of: ' + codexObject.page)
-                            console.log(
-                                'dashed field: ' + j + easyArray[i + 3] + '\n'
-                            )
                             if (/([0-9]|\-)+/g.test(easyArray[i + 3])) {
                                 // console.log('passed first')
                                 codexObject.page = codexObject.page.concat(

--- a/src/parse-pdf.js
+++ b/src/parse-pdf.js
@@ -39,7 +39,7 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
             })
             if (flagFutureElements === 0) {
                 counter += textArray.push(decodedText)
-            // } else if (newText === 'ameduaodnw') {
+                // } else if (newText === 'ameduaodnw') {
             } else if (newText === 'ft' || newText === 'fl') {
                 counter--
                 const lastText = textArray.pop()
@@ -50,8 +50,13 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
                 )
                 // console.log(`adding ${fixedText}`)
                 counter += textArray.push(fixedText)
-            // } else if (newText === 'ameduaodnw') {
-            } else if (newText === 'th' || newText === 'wh' || newText === 'fi' || newText === 'ff') {
+                // } else if (newText === 'ameduaodnw') {
+            } else if (
+                newText === 'th' ||
+                newText === 'wh' ||
+                newText === 'fi' ||
+                newText === 'ff'
+            ) {
                 counter--
                 let fixedText = ''
                 const lastText = textArray.pop()

--- a/src/parse-pdf.js
+++ b/src/parse-pdf.js
@@ -1,43 +1,107 @@
-const fs = require('fs');
-const path = require('path');
-const PDFParser = require('pdf2json');
+const fs = require('fs')
+const path = require('path')
+const PDFParser = require('pdf2json')
 // const figlet = require('figlet');
 // const shell = require('shelljs');
+const consts = require('./common/consts')
 
-const pdfParser = new PDFParser();
+const pdfParser = new PDFParser()
 
 pdfParser.on('pdfParser_dataError', (errData) => {
-    console.error(errData.parserError);
-});
+    console.error(errData.parserError)
+})
 
 pdfParser.on('pdfParser_dataReady', (pdfData) => {
-    const date = new Date().toLocaleString('en-AU');
-    const isoDate = new Date(parseInt(date)).toISOString();
+    const date = new Date().toLocaleString('en-AU')
+    const isoDate = new Date(date).toISOString()
 
-    console.log('Parsed PDF Data');
+    console.log('Parsed PDF Data')
 
-    let counter = 0;
-    const textArray = [];
-    const pages = pdfData['formImage']['Pages'];
-    pages.forEach(page => {
-        const texts = page['Texts'];
-        texts.forEach(text => {
-            const representation = text['R'][0];
-            const textString = representation['T'];
-            const decodedText = decodeURIComponent(textString);
-            counter += textArray.push(decodedText);
-        });
-    });
+    let counter = 0
+    let flagFutureElements = 0
+    const textArray = []
+    const pages = pdfData['formImage']['Pages']
+    pages.forEach((page) => {
+        const texts = page['Texts']
+        texts.forEach((text, textIndex) => {
+            const textString = text['R'][0]['T']
+            let decodedText = decodeURIComponent(textString)
+            let newText = ''
+            consts.brokenDecodedTextList.forEach((brokenText) => {
+                if (textString === brokenText.brokenEncoding) {
+                    decodedText = brokenText.fixedEncoding
+                    flagFutureElements += brokenText.flagElements.valueOf()
+                    newText = brokenText.fixedEncoding
+                }
+            })
+            if (flagFutureElements === 0) {
+                counter += textArray.push(decodedText)
+            } else if (newText === 'ft' || newText === 'fl') {
+                counter--
+                const lastText = textArray.pop()
+                const nextText = texts[textIndex + 1]
+                const fixedText = lastText.concat(
+                    newText,
+                    decodeURIComponent(nextText['R'][0]['T'])
+                )
+                // console.log(`adding ${fixedText}`)
+                counter += textArray.push(fixedText)
+            } else if (newText === 'th' || newText === 'wh' || newText === 'fi') {
+                counter--
+                let fixedText = ''
+                const lastText = textArray.pop()
+                const nextText = texts[textIndex + 1]
+                if (lastText.slice(lastText.length - 3) === '%20') {
+                    fixedText = lastText.concat(
+                        newText[0].toUpperCase() + newText.substring(1),
+                        decodeURIComponent(nextText['R'][0]['T'])
+                    )
+                } else if (Number.isInteger(parseInt(lastText))) {
+                    counter += textArray.push(lastText)
+                    const temp = newText[0].toUpperCase() + newText.substring(1)
+                    fixedText = temp.concat(
+                        decodeURIComponent(nextText['R'][0]['T'])
+                    )
+                } else {
+                    fixedText = lastText.concat(
+                        newText,
+                        decodeURIComponent(nextText['R'][0]['T'])
+                    )
+                }
+                // console.log(`adding ${fixedText}`)
+                counter += textArray.push(fixedText)
+            } else {
+                // console.log(`flagFutureElements is ${flagFutureElements}`)
+                // console.log(`skipping adding ${decodedText}`)
+                while (flagFutureElements > 0) {
+                    flagFutureElements -= 1
+                    break
+                }
+            }
+        })
+    })
 
-    console.log(`Collected ${counter} text strings`);
+    console.log(`Collected ${counter} text strings`)
 
-    fs.writeFileSync(path.join(__dirname, '..', `/resources/json/${isoDate}-easyarray.json`), JSON.stringify(textArray), () => {
-        console.dir(textArray);
-    });
+    fs.writeFileSync(
+        path.join(__dirname, '..', `/resources/json/${isoDate}-easyarray.json`),
+        JSON.stringify(textArray),
+        () => {
+            console.dir(textArray)
+        }
+    )
 
-    fs.writeFileSync(path.join(__dirname, '..', `/resources/json/${isoDate}-rawpdfconversion.json`), JSON.stringify(pdfData), () => {
-        console.dir(pdfData);
-    });
+    fs.writeFileSync(
+        path.join(
+            __dirname,
+            '..',
+            `/resources/json/${isoDate}-rawpdfconversion.json`
+        ),
+        JSON.stringify(pdfData),
+        () => {
+            console.dir(pdfData)
+        }
+    )
 
     // let target = 110;
     // setInterval(() => {
@@ -49,7 +113,14 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
     // foreach(pages.Texts)
     // foreach(texts.R[0])
     // R.T === the text object...
-});
+})
 
-const myArgs = process.argv.slice(2);
-pdfParser.loadPDF(path.join(__dirname, '..', `/resources/pdf/${myArgs[0]}`));
+const myArgs = process.argv.slice(2)
+if (myArgs[0] === null || myArgs[0] === undefined) {
+    console.error(
+        'Invalid script call: Please provide PDF for parsing in the format'
+    )
+    console.log('yarn convertpdf pdfname.pdf')
+} else {
+    pdfParser.loadPDF(path.join(__dirname, '..', `/resources/pdf/${myArgs[0]}`))
+}

--- a/src/parse-pdf.js
+++ b/src/parse-pdf.js
@@ -13,7 +13,9 @@ pdfParser.on('pdfParser_dataError', (errData) => {
 
 pdfParser.on('pdfParser_dataReady', (pdfData) => {
     const date = new Date().toLocaleString('en-AU')
+    console.log(`date: ${date}`)
     const isoDate = new Date(date).toISOString()
+    console.log(`isoDate: ${isoDate}`)
 
     console.log('Parsed PDF Data')
 
@@ -27,16 +29,19 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
             const textString = text['R'][0]['T']
             let decodedText = decodeURIComponent(textString)
             let newText = ''
+            let alternateNewText = ''
             consts.brokenDecodedTextList.forEach((brokenText) => {
                 if (textString === brokenText.brokenEncoding) {
                     decodedText = brokenText.fixedEncoding
                     flagFutureElements += brokenText.flagElements.valueOf()
                     newText = brokenText.fixedEncoding
+                    alternateNewText = brokenText.alternateFixedEncoding
                 }
             })
             if (flagFutureElements === 0) {
                 counter += textArray.push(decodedText)
-            } else if (newText === 'ft' || newText === 'fl') {
+            } else if (newText === 'ameduaodnw') {
+            // } else if (newText === 'ft' || newText === 'fl') {
                 counter--
                 const lastText = textArray.pop()
                 const nextText = texts[textIndex + 1]
@@ -46,7 +51,8 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
                 )
                 // console.log(`adding ${fixedText}`)
                 counter += textArray.push(fixedText)
-            } else if (newText === 'th' || newText === 'wh' || newText === 'fi') {
+            } else if (newText === 'ameduaodnw') {
+            // } else if (newText === 'th' || newText === 'wh' || newText === 'fi' || newText === 'ff') {
                 counter--
                 let fixedText = ''
                 const lastText = textArray.pop()
@@ -56,6 +62,8 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
                         newText[0].toUpperCase() + newText.substring(1),
                         decodeURIComponent(nextText['R'][0]['T'])
                     )
+                    if (alternateNewText !== undefined)
+                        fixedText = alternateNewText
                 } else if (Number.isInteger(parseInt(lastText))) {
                     counter += textArray.push(lastText)
                     const temp = newText[0].toUpperCase() + newText.substring(1)

--- a/src/parse-pdf.js
+++ b/src/parse-pdf.js
@@ -40,8 +40,8 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
             })
             if (flagFutureElements === 0) {
                 counter += textArray.push(decodedText)
-            } else if (newText === 'ameduaodnw') {
-            // } else if (newText === 'ft' || newText === 'fl') {
+            // } else if (newText === 'ameduaodnw') {
+            } else if (newText === 'ft' || newText === 'fl') {
                 counter--
                 const lastText = textArray.pop()
                 const nextText = texts[textIndex + 1]
@@ -51,8 +51,8 @@ pdfParser.on('pdfParser_dataReady', (pdfData) => {
                 )
                 // console.log(`adding ${fixedText}`)
                 counter += textArray.push(fixedText)
-            } else if (newText === 'ameduaodnw') {
-            // } else if (newText === 'th' || newText === 'wh' || newText === 'fi' || newText === 'ff') {
+            // } else if (newText === 'ameduaodnw') {
+            } else if (newText === 'th' || newText === 'wh' || newText === 'fi' || newText === 'ff') {
                 counter--
                 let fixedText = ''
                 const lastText = textArray.pop()

--- a/src/populate-codices.js
+++ b/src/populate-codices.js
@@ -60,10 +60,16 @@ const loadFile = (codicesFileName, easyArrayFileName) => {
                     addCreatureText = true
                     // console.log(`Adding text for ${codex.creature}`)
                     textIncrementer += 2 // skips next two garbage texts (meta + page num)
-                } else if (prevText === consts.emailMeta && text === consts.finalCodicesPage) {
+                } else if (
+                    prevText === consts.emailMeta &&
+                    text === consts.finalCodicesPage
+                ) {
                     // console.log(`Stopping last ${easyArray[textIncrementer]}...`)
                     creatureFinished = true
-                } else if (prevText === consts.emailMeta && text === parseInt(nextCreaturePage).toString()) {
+                } else if (
+                    prevText === consts.emailMeta &&
+                    text === parseInt(nextCreaturePage).toString()
+                ) {
                     // i.e. this text is the next creature's page, it's time to stop!!!
                     // console.log(`Stopping ${easyArray[textIncrementer]}...`)
                     creatureFinished = true

--- a/src/populate-codices.js
+++ b/src/populate-codices.js
@@ -46,26 +46,19 @@ const loadFile = (codicesFileName, easyArrayFileName) => {
             let creatureFinished = false
             let addCreatureText = false
             const codexRawTextArray = []
-            console.log(`Dealing with a ${codex.creature}`)
+            // console.log(`Dealing with a ${codex.creature}`)
             while (textIncrementer < easyArray.length && !creatureFinished) {
                 const prevText = easyArray[textIncrementer - 1]
                 const text = easyArray[textIncrementer]
                 // console.log(text)
                 // find creature in question
-                // if (easyArray[textIncrementer] === consts.emailMeta) {
-                //     console.log(`meta: ${easyArray[textIncrementer]}`)
-                //     console.log(`page(text): ${easyArray[textIncrementer + 1]}`)
-                //     console.log(`page(codex): ${codex.page}`)
-                // } else if (easyArray[textIncrementer] === 'Zoog') {
-                //     console.log('ZOOG!')
-                // }
                 if (
                     easyArray[textIncrementer + 1] === consts.emailMeta &&
                     easyArray[textIncrementer + 2] === codex.page
                 ) {
                     // found the creature needed, begin adding creature text
                     addCreatureText = true
-                    console.log(`Adding text for ${codex.creature}`)
+                    // console.log(`Adding text for ${codex.creature}`)
                     textIncrementer += 2 // skips next two garbage texts (meta + page num)
                 } else if (prevText === consts.emailMeta && text === consts.finalCodicesPage) {
                     // console.log(`Stopping last ${easyArray[textIncrementer]}...`)
@@ -82,7 +75,7 @@ const loadFile = (codicesFileName, easyArrayFileName) => {
                 textIncrementer += 1
             }
             if (codexRawTextArray !== []) {
-                console.log(`Adding data for ${codex.creature} to file\n`)
+                // console.log(`Adding data for ${codex.creature} to file\n`)
                 codicesObjects.push(codexRawTextArray)
             }
         })

--- a/src/populate-codices.js
+++ b/src/populate-codices.js
@@ -1,0 +1,124 @@
+const fs = require('fs')
+const path = require('path')
+const inquirer = require('inquirer')
+// const chalk = require('chalk');
+const consts = require('./common/consts')
+
+const date = new Date().toLocaleString('en-AU')
+const isoDate = new Date(date).toISOString()
+
+const files = fs.readdirSync(path.join(__dirname, '..', 'resources/json'))
+
+const questions = [
+    {
+        type: 'list',
+        name: 'CODICESLOCATION',
+        message: 'Which Codices JSON file should be loaded?',
+        choices: files
+    },
+    {
+        type: 'list',
+        name: 'EASYLOCATION',
+        message: 'Which Easy Text Array file should be loaded?',
+        choices: files
+    }
+]
+
+const loadFile = (codicesFileName, easyArrayFileName) => {
+    const BreakException = {}
+    let fileContent = fs.readFileSync(codicesFileName)
+    const creatureCodices = JSON.parse(fileContent)
+    fileContent = fs.readFileSync(easyArrayFileName)
+    const easyArray = JSON.parse(fileContent)
+    const codicesObjects = []
+
+    // populate
+    try {
+        creatureCodices.forEach((codex, codicesIndex) => {
+            let textIncrementer = 0
+            const nextCreature = creatureCodices[codicesIndex + 1]
+            let nextCreaturePage = ''
+            if (nextCreature === undefined) {
+                nextCreaturePage = 'codicesFinished'
+            } else {
+                nextCreaturePage = nextCreature.page
+            }
+            let creatureFinished = false
+            let addCreatureText = false
+            const codexRawTextArray = []
+            console.log(`Dealing with a ${codex.creature}`)
+            while (textIncrementer < easyArray.length && !creatureFinished) {
+                const prevText = easyArray[textIncrementer - 1]
+                const text = easyArray[textIncrementer]
+                // console.log(text)
+                // find creature in question
+                // if (easyArray[textIncrementer] === consts.emailMeta) {
+                //     console.log(`meta: ${easyArray[textIncrementer]}`)
+                //     console.log(`page(text): ${easyArray[textIncrementer + 1]}`)
+                //     console.log(`page(codex): ${codex.page}`)
+                // } else if (easyArray[textIncrementer] === 'Zoog') {
+                //     console.log('ZOOG!')
+                // }
+                if (
+                    easyArray[textIncrementer + 1] === consts.emailMeta &&
+                    easyArray[textIncrementer + 2] === codex.page
+                ) {
+                    // found the creature needed, begin adding creature text
+                    addCreatureText = true
+                    console.log(`Adding text for ${codex.creature}`)
+                    textIncrementer += 2 // skips next two garbage texts (meta + page num)
+                } else if (prevText === consts.emailMeta && text === consts.finalCodicesPage) {
+                    // console.log(`Stopping last ${easyArray[textIncrementer]}...`)
+                    creatureFinished = true
+                } else if (prevText === consts.emailMeta && text === parseInt(nextCreaturePage).toString()) {
+                    // i.e. this text is the next creature's page, it's time to stop!!!
+                    // console.log(`Stopping ${easyArray[textIncrementer]}...`)
+                    creatureFinished = true
+                } else if (addCreatureText && text !== consts.emailMeta) {
+                    // console.log(`Pushing ${easyArray[textIncrementer]}...`)
+                    // this is regular text, add to array
+                    codexRawTextArray.push(easyArray[textIncrementer])
+                }
+                textIncrementer += 1
+            }
+            if (codexRawTextArray !== []) {
+                console.log(`Adding data for ${codex.creature} to file\n`)
+                codicesObjects.push(codexRawTextArray)
+            }
+        })
+    } catch (e) {
+        if (e !== BreakException) throw e
+        console.log(`Successfully finished populating Creature Codices`)
+    }
+
+    fs.writeFile(
+        path.join(
+            __dirname,
+            '..',
+            `/resources/json/${isoDate}-populatedcodices.json`
+        ),
+        JSON.stringify(codicesObjects),
+        () => {
+            console.dir(codicesObjects, { maxArrayLength: 4 })
+        }
+    )
+}
+
+inquirer
+    .prompt(questions)
+    .then((answers) => {
+        const { CODICESLOCATION, EASYLOCATION } = answers
+        loadFile(
+            path.join(__dirname + '/..' + '/resources/json/' + CODICESLOCATION),
+            path.join(__dirname + '/..' + '/resources/json/' + EASYLOCATION)
+        )
+    })
+    .catch((error) => {
+        if (error.isTtyError) {
+            console.log(
+                "Prompt couldn't be rendered in the current environment"
+            )
+        } else {
+            console.log('Error performing Inquirer:', error)
+        }
+    })

--- a/src/test.js
+++ b/src/test.js
@@ -1,13 +1,35 @@
-const date = new Date();
-const localDate = date.toLocaleString('en-AU');
-console.dir(localDate);
-const isoLocalDate = new Date(localDate).toISOString();
+const date = new Date()
+const localDate = date.toLocaleString('en-AU')
+const consts = require('./common/consts')
+console.dir(localDate)
+const isoLocalDate = new Date(localDate).toISOString()
 // console.dir(date.getTime());
-console.dir(isoLocalDate);
+console.dir(isoLocalDate)
 
-let target = 115;
+// let target = 115;
 
-setInterval(() => {
-    process.stdout.write('\rTime remaining: ' + target + ' seconds');
-    target--;
-}, 1000);
+// setInterval(() => {
+//     process.stdout.write('\rTime remaining: ' + target + ' seconds');
+//     target--;
+// }, 1000);
+
+let flagFutureElements = 0
+decodedText = 'Bearfolk Chie'
+consts.brokenDecodedTextList.forEach((brokenText) => {
+    if (decodedText === brokenText.brokenEncoding) {
+        decodedText = brokenText.fixedEncoding
+        flagFutureElements += brokenText.flagElements.valueOf()
+        console.log(`flagFutureElements set to ${flagFutureElements}`)
+    }
+})
+// if (flagFutureElements <= 0) {
+//     counter += textArray.push(decodedText)
+// } else {
+//     console.log(`flagFutureElements is ${flagFutureElements}`)
+//     console.log(`skipping adding ${decodedText}`)
+// }
+// console.log(`decodedText is ${decodedText}`)
+
+const teststr = '192-205'
+const test = parseInt(teststr)
+console.log(test.toString())

--- a/src/test.js
+++ b/src/test.js
@@ -26,8 +26,7 @@ const teststr = '192-205'
 const test = parseInt(teststr)
 console.log(test.toString())
 
-const target = 115
-
+// const target = 115
 // setInterval(() => {
 //     process.stdout.write('\rTime remaining: ' + target + ' seconds')
 //     target--


### PR DESCRIPTION
- populatecodices: adds more fields to the codex, currently only have `creature`, `page`, this creates a new file called `XX-populatedcodices.json` which contains more data
- cleancodices: cleans up data in `populatedcodices.json` by replacing dodgy characters that couldn't be parsed by the PDF Parser. unfortunately, this seems to be a persistent issue, and i saw it in a Python PDF parsing module too (`pdfminer`) 🙁 

also I have properly fixed up the `parsecodices` here, it actually gets creature names right!!!
nothing else really changed, a few minor style and convention things